### PR TITLE
add Cvoid to cxxtype

### DIFF
--- a/src/CxxInterface.jl
+++ b/src/CxxInterface.jl
@@ -119,7 +119,7 @@ export cxxname
 const cxxtype = Dict{Type,CxxType}(Bool => "uint8_t", Int8 => "int8_t", Int16 => "int16_t", Int32 => "int32_t", Int64 => "int64_t",
                                    UInt8 => "uint8_t", UInt16 => "uint16_t", UInt32 => "uint32_t", UInt64 => "uint64_t",
                                    Float32 => "float", Float64 => "double", Complex{Float32} => "float _Complex",
-                                   Complex{Float64} => "double _Complex", Ptr{Cvoid} => "void *")
+                                   Complex{Float64} => "double _Complex", Ptr{Cvoid} => "void *", Cvoid=>"void")
 export cxxtype
 
 ################################################################################


### PR DESCRIPTION
Thanks a lot, @eschnett for this package! Since `void` is a common return type, I found it convenient to map it automatically.